### PR TITLE
adds fix for explanation of dcmpl instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,7 @@ p. 157: BNFC was not ported to Java, C, C++, etc.; rather, the mentioned languag
 ### Appendix A
 
 p. 175: The arcs in this diagram are not really traceable.
+
+### Appendix A
+
+p. 193: dcmpl explanation should be "compare if >*"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ just be `<`.
 p. 112: "just a dummy `Object`".  Now, Java has class `Void` for that
 purpose.  Change would affect the following code.
 
+p. 105: The generated code for the while loop in the middle column contains `ifeq goto END`. It should be `ifeq END` without the goto.
+
 ### Chapter 7, Functional Programming Languages
 
 #### 7.3 Anonymous functions


### PR DESCRIPTION
on dcmpl fix:

dcmpl and dcmpg behave the same except for their treatment of 'NaN'

The current explanation misleads the reader to concluding that dcmpl is different from dcmpg on non-NaN double values.

Ref: https://docs.oracle.com/javase/specs/jvms/se6/html/Instructions2.doc3.html#dcmpop